### PR TITLE
auth,context: clean up usage of context

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,12 +1,13 @@
 package auth
 
 import (
-	"context"
 	"net/http"
 	"strings"
 
+	auth "github.com/abbot/go-http-auth"
+
+	"github.com/Go-SIP/gosip/context"
 	"github.com/Go-SIP/gosip/users"
-	"github.com/abbot/go-http-auth"
 )
 
 type UserDatabase interface {
@@ -60,10 +61,6 @@ func (ah *Handler) Basic(h http.Handler) http.Handler {
 		}))
 }
 
-type username string
-
-var authUsername username = "username"
-
 func (ah *Handler) Token(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tokenHeader := r.Header.Get("Authorization")
@@ -80,13 +77,6 @@ func (ah *Handler) Token(h http.Handler) http.Handler {
 			return
 		}
 
-		ctx := context.WithValue(r.Context(), authUsername, user.Username())
-		r = r.WithContext(ctx)
-
-		h.ServeHTTP(w, r)
+		h.ServeHTTP(w, r.WithContext(context.WithUsername(r.Context(), user.Username())))
 	})
-}
-
-func Username(ctx context.Context) string {
-	return ctx.Value(authUsername).(string)
 }

--- a/context/context.go
+++ b/context/context.go
@@ -1,0 +1,54 @@
+package context
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// key is used for private context keys.
+type key int
+
+const (
+	prometheusURLKey key = iota
+	usernameKey
+)
+
+// ErrContextMissing is returned when a context is missing a value.
+type ErrContextMissing struct {
+	// Value is the value that is missing from the context.
+	Value string
+}
+
+// Error implements the error interface.
+func (e *ErrContextMissing) Error() string {
+	return fmt.Sprintf("context missing %s", e.Value)
+}
+
+// WithPrometheusURL returns a copy of the given context with a Prometheus URL stored.
+func WithPrometheusURL(ctx context.Context, u *url.URL) context.Context {
+	return context.WithValue(ctx, prometheusURLKey, u)
+}
+
+// PrometheusURLFromContext returns a Prometheus URL from the context.
+func PrometheusURLFromContext(ctx context.Context) (*url.URL, error) {
+	u, ok := ctx.Value(prometheusURLKey).(*url.URL)
+	if !ok {
+		return nil, &ErrContextMissing{"Prometheus URL"}
+	}
+	return u, nil
+}
+
+// WithUsername returns a copy of the given context with a username stored.
+func WithUsername(ctx context.Context, u string) context.Context {
+	return context.WithValue(ctx, usernameKey, u)
+}
+
+// UsernameFromContext returns a username from the context.
+func UsernameFromContext(ctx context.Context) (string, error) {
+	u, ok := ctx.Value(usernameKey).(string)
+	if !ok {
+		return "", &ErrContextMissing{"username"}
+	}
+	return u, nil
+}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Go-SIP/gosip/tenant"
 	"github.com/Go-SIP/gosip/ui"
 	"github.com/Go-SIP/gosip/users"
+
 	_ "github.com/lib/pq"
 )
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -4,16 +4,23 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/abbot/go-http-auth"
+	auth "github.com/abbot/go-http-auth"
 )
 
+// UI serves Go-SIP user interface.
 type UI struct{}
 
+// New creates and returns a new UI instance.
 func New() *UI {
 	return &UI{}
 }
 
+// ServeHTTP implements the http.Handler interface.
 func (u *UI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	info := auth.FromContext(r.Context())
+	if info == nil {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
 	fmt.Fprintf(w, "<html><body><h1>Successfully Authenticated %s!</h1></body></html>", info.Username)
 }


### PR DESCRIPTION
This commit cleans up the usage of context in various packages.
Essentially, this makes the setting and getting of values from contexts
consistent and sane so that we catch type assertion errors.

cc @metalmatze 